### PR TITLE
Enable auto pagination and allow specifying repo types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git_org_file_scanner (0.1.0)
+    git_org_file_scanner (0.1.1)
       octokit
 
 GEM
@@ -11,7 +11,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     diff-lcs (1.3)
-    faraday (0.15.3)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     jaro_winkler (1.5.1)
     multipart-post (2.0.0)
@@ -37,7 +37,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.60.0)
+    rubocop (0.61.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
@@ -62,4 +62,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/README.md
+++ b/README.md
@@ -33,11 +33,16 @@ We can initialize the scannerlike this:
 scanner = GitOrgFileScanner::Scanner.new('<your GitHub access token>', 'habitat-sh')
 ```
 
+To limit the repositories to search to those that match a specific Github repo type you can pass in a valid repo type ('all', 'public', 'member', 'sources', 'forks', 'private'). If no type is specified then 'sources' will be used.
+```ruby
+scanner = GitOrgFileScanner::Scanner.new('<your GitHub access token>', 'habitat-sh', 'public')
+```
+
 Let's say we want a list of all repos in the [habitat-sh GitHub Org](https://github.com/habitat-sh) that DO contain a CONTRIBUTING.md file. We would request that list like this:
 
 ```ruby
 scanner.contain_file('CONTRIBUTING.md')
-=> ["habitat-sh/habitat", "habitat-sh/core-plans", "habitat-sh/habitat-launch", "habitat-sh/urlencoded", "habitat-sh/habitat-operator"] 
+=> ["habitat-sh/habitat", "habitat-sh/core-plans", "habitat-sh/habitat-launch", "habitat-sh/urlencoded", "habitat-sh/habitat-operator"]
 ```
 
 Now what if we want a list of all repos that do NOT contain a CONTRIBUTING.md file?

--- a/git_org_file_scanner.gemspec
+++ b/git_org_file_scanner.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"
   spec.add_runtime_dependency "octokit"

--- a/lib/git_org_file_scanner.rb
+++ b/lib/git_org_file_scanner.rb
@@ -6,9 +6,10 @@ module GitOrgFileScanner
   class Scanner
     attr_accessor :org
 
-    def initialize(access_token, org)
+    def initialize(access_token, org, type = 'sources')
       @octokit_client = setup_client(access_token)
       @org = org
+      @type = type
       @org_repositories = org_repositories
     end
 
@@ -49,7 +50,7 @@ module GitOrgFileScanner
     private
 
     def org_repositories
-      @octokit_client.org_repositories(org)
+      @octokit_client.org_repositories(@org, {:type => @type})
     end
 
     def contains_file?(repo_name, file)

--- a/lib/git_org_file_scanner.rb
+++ b/lib/git_org_file_scanner.rb
@@ -7,9 +7,20 @@ module GitOrgFileScanner
     attr_accessor :org
 
     def initialize(access_token, org)
-      @octokit_client = Octokit::Client.new(access_token: access_token)
+      @octokit_client = setup_client(access_token)
       @org = org
       @org_repositories = org_repositories
+    end
+
+    # setup an oktokit client with auto_pagination turned on so we get all the repos
+    # returned even in large organizations
+    #
+    # @param token [String] the github access token
+    # @return [Octokit::Client] the oktokit client object
+    def setup_client(token)
+      client = Octokit::Client.new(access_token: token)
+      client.auto_paginate = true
+      client
     end
 
     def contain_file(file)


### PR DESCRIPTION
Without auto pagination enabled you only get a tiny subset of the total repositories searched
This also allows you to specify the repo type with a default of 'sources'. Setting the default to sources skips repos that are forked where you don't necessarily control the content.